### PR TITLE
Issue4 rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 vendor
 tmp
 build
+composer.lock

--- a/src/CronLingo/CronLingo.php
+++ b/src/CronLingo/CronLingo.php
@@ -15,7 +15,7 @@ class CronLingo
      * @param $string
      * @return string
      */
-    public static function cron($string)
+    public static function fromExpression($string)
     {
         return self::getParser()->parse($string);
     }

--- a/test/CronLingo/CronLingoTest.php
+++ b/test/CronLingo/CronLingoTest.php
@@ -6,7 +6,7 @@ class CronLingoTest extends \PHPUnit_Framework_TestCase
 {
     public function testCron()
     {
-        $this->assertInternalType('string', \CronLingo\CronLingo::cron('Every day at midnight'));
+        $this->assertInternalType('string', \CronLingo\CronLingo::fromExpression('Every day at midnight'));
     }
 
     public function testGetParser()


### PR DESCRIPTION
Renamed 'cron' method to 'fromExpression' in CronLingo class to match the README. Updated related test.
