### PR TITLE
travis: drop unused fast_finish

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,3 @@ sudo: false
 install: travis_retry composer install --no-interaction --prefer-source
 
 script: phpunit --coverage-text --colors
-
-matrix:
-  fast_finish: true


### PR DESCRIPTION
As there are no allowed_failures, this has no added value.
